### PR TITLE
Allow for @inheritDoc tag with uppercase D

### DIFF
--- a/src/FileParser/FileParser.php
+++ b/src/FileParser/FileParser.php
@@ -251,7 +251,7 @@ class FileParser
     {
         $tagCollection = $this->docblockParser->parseComment($text);
 
-        if ($tagCollection->hasTag('inheritdoc')) {
+        if ($tagCollection->hasTag('inheritdoc') || $tagCollection->hasTag('inheritDoc')) {
             return ['inherit' => true];
         }
 


### PR DESCRIPTION
Simple fix to allow both `@inheritdoc` and `@inheritDoc` more work will be required to support `{@inheritDoc}` which seems to indicate only the description should be inherited.