### PR TITLE
Type refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+.vscode
 vendor
 phpdoccheck.phar
 .phpdoccheck

--- a/README.md
+++ b/README.md
@@ -2,27 +2,20 @@
 Check PHP files within a directory for appropriate use of Docblocks. This is a fork of the original work from @dancryer but just adding support for newer php features
 
 ## Installation
-**Composer**:<br>
-<code>
-composer require neild3r/php-docblock-checker
-</code>
+### Composer
+`composer require neild3r/php-docblock-checker`
 
 ## Usage
-**CMD**:<br>
-<code>
-call vendor/bin/phpdoccheck {params}
-</code>
+### CMD
+`call vendor/bin/phpdoccheck {params}`
 
 To validate changed files in the last git commit:
 
-<code>
-git diff --name-only HEAD HEAD^ | ./vendor/bin/phpdoccheck --from-stdin
-</code>
+`git diff --name-only HEAD HEAD^ | ./vendor/bin/phpdoccheck --from-stdin`
 
 If used within a travis context, this may be useful:
-<code>
-git diff --name-only ${TRAVIS_COMMIT_RANGE:-"HEAD^"} | ./vendor/bin/phpdoccheck --from-stdin
-</code>
+
+`git diff --name-only ${TRAVIS_COMMIT_RANGE:-"HEAD^"} | ./vendor/bin/phpdoccheck --from-stdin`
 
 ## Parameters
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # PHP DocBlock Checker
-Check PHP files within a directory for appropriate use of Docblocks.
+Check PHP files within a directory for appropriate use of Docblocks. This is a fork of the original work from @dancryer but just adding support for newer php features
 
 ## Installation
 **Composer**:<br>
 <code>
-composer require dancryer/php-docblock-checker
+composer require neild3r/php-docblock-checker
 </code>
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     {
       "name" "Neil Brayfield",
       "role": "developer"
+    },
     {
       "name": "Dan Cryer",
       "email": "dan.cryer@block8.co.uk",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "license": "BSD-2-Clause",
   "authors": [
     {
-      "name" "Neil Brayfield",
+      "name": "Neil Brayfield",
       "role": "developer"
     },
     {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "dancryer/php-docblock-checker",
+  "name": "neild3r/php-docblock-checker",
   "description": "A simple tool for checking that your PHP classes and methods use docblocks.",
   "minimum-stability": "stable",
   "type": "library",
@@ -16,6 +16,9 @@
   "license": "BSD-2-Clause",
   "authors": [
     {
+      "name" "Neil Brayfield",
+      "role": "developer"
+    {
       "name": "Dan Cryer",
       "email": "dan.cryer@block8.co.uk",
       "homepage": "http://www.block8.co.uk",
@@ -23,8 +26,8 @@
     }
   ],
   "support": {
-    "issues": "https://github.com/dancryer/php-docblock-checker/issues",
-    "source": "https://github.com/dancryer/php-docblock-checker"
+    "issues": "https://github.com/neild3r/php-docblock-checker/issues",
+    "source": "https://github.com/neild3r/php-docblock-checker"
   },
   "require": {
     "php": ">=5.5",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
   },
   "require-dev": {
     "jakub-onderka/php-parallel-lint": "0.8.*",
-    "phpstan/phpstan": "^0.11.5",
+    "phpstan/phpstan": "^1.10.3",
     "squizlabs/php_codesniffer": "^3.4",
     "phperf/xh-tool": "^1.1",
     "phpunit/phpunit": "^4.8"

--- a/src/Check/MethodCheck.php
+++ b/src/Check/MethodCheck.php
@@ -15,13 +15,14 @@ class MethodCheck extends Check
     {
         foreach ($file->getMethods() as $name => $method) {
             $treatAsError = true;
-            if (false === $method['has_return'] &&
+            $params = $method->getParams();
+            if (false === $method->hasReturn() &&
                 $this->config->isOnlySignatures() &&
-                (empty($method['params']) || 0 === count($method['params']))) {
+                (empty($params) || 0 === count($params))) {
                 $treatAsError = false;
             }
 
-            if ($method['docblock'] === null) {
+            if ($method->getDocblock() === null) {
                 if (true === $treatAsError) {
                     $this->fileStatus->add(new MethodError($file->getFileName(), $name, $method['line'], $name));
                 } else {

--- a/src/Check/ParamCheck.php
+++ b/src/Check/ParamCheck.php
@@ -15,39 +15,40 @@ class ParamCheck extends Check
     public function check(FileInfo $file)
     {
         foreach ($file->getMethods() as $name => $method) {
+            $docblock = $method->getDocblock();
             // If the docblock is inherited, we can't check for params and return types:
-            if (isset($method['docblock']['inherit']) && $method['docblock']['inherit']) {
+            if (isset($docblock['inherit']) && $docblock['inherit']) {
                 continue;
             }
 
-            foreach ($method['params'] as $param => $type) {
-                if (!isset($method['docblock']['params'][$param])) {
+            foreach ($method->getParams() as $param => $type) {
+                if (!isset($docblock['params'][$param])) {
                     $this->fileStatus->add(
-                        new ParamMissingWarning($file->getFileName(), $name, $method['line'], $name, $param)
+                        new ParamMissingWarning($file->getFileName(), $name, $method->getLine(), $name, $param)
                     );
                     continue;
                 }
 
                 if (!empty($type)) {
-                    $docBlockTypes = explode('|', $method['docblock']['params'][$param]);
+                    $docBlockTypes = explode('|', $docblock['params'][$param]);
                     $methodTypes = explode('|', $type);
 
                     sort($docBlockTypes);
                     sort($methodTypes);
 
                     if ($docBlockTypes !== $methodTypes) {
-                        if ($type === 'array' && substr($method['docblock']['params'][$param], -2) === '[]') {
+                        if ($type === 'array' && substr($docblock['params'][$param], -2) === '[]') {
                             // Do nothing because this is fine.
                         } else {
                             $this->fileStatus->add(
                                 new ParamMismatchWarning(
                                     $file->getFileName(),
                                     $name,
-                                    $method['line'],
+                                    $method->getLine(),
                                     $name,
                                     $param,
                                     $type,
-                                    $method['docblock']['params'][$param]
+                                    $docblock['params'][$param]
                                 )
                             );
                         }

--- a/src/Check/ReturnCheck.php
+++ b/src/Check/ReturnCheck.php
@@ -15,27 +15,28 @@ class ReturnCheck extends Check
     public function check(FileInfo $file)
     {
         foreach ($file->getMethods() as $name => $method) {
-            if (empty($method['return'])) {
+            $docblock = $method->getDocblock();
+            if ($method->getReturnType() === null) {
                 // Nothing to check.
                 continue;
             }
 
-            if (empty($method['docblock']['return'])) {
+            if (empty($docblock['return'])) {
                 $this->fileStatus->add(
                     new ReturnMissingWarning(
                         $file->getFileName(),
                         $name,
-                        $method['line'],
+                        $method->getLine(),
                         $name
                     )
                 );
                 continue;
             }
 
-            $returnTypes = $method['docblock']['return'];
-            $methodTypes = $method['return'];
+            $returnTypes = $docblock['return'];
+            $methodTypes = $method->getReturnType();
 
-            if ($method['return'] === 'array'
+            if ($method->getReturnType() === 'array'
                 && !is_array($returnTypes)
                 && substr($returnTypes, -2) === '[]'
             ) {
@@ -48,9 +49,9 @@ class ReturnCheck extends Check
                     new ReturnMismatchWarning(
                         $file->getFileName(),
                         $name,
-                        $method['line'],
+                        $method->getLine(),
                         $name,
-                        is_array($methodTypes) ? implode('|', $methodTypes) : $methodTypes,
+                        $methodTypes->toString(),
                         is_array($returnTypes) ? implode('|', $returnTypes) : $returnTypes
                     )
                 );

--- a/src/Check/ReturnCheck.php
+++ b/src/Check/ReturnCheck.php
@@ -32,20 +32,26 @@ class ReturnCheck extends Check
                 continue;
             }
 
-            if ($method['return'] === 'array' && substr($method['docblock']['return'], -2) === '[]') {
+            $returnTypes = $method['docblock']['return'];
+            $methodTypes = $method['return'];
+
+            if ($method['return'] === 'array'
+                && !is_array($returnTypes)
+                && substr($returnTypes, -2) === '[]'
+            ) {
                 // Do nothing because this is fine.
                 continue;
             }
 
-            if ($method['return'] !== $method['docblock']['return']) {
+            if ($methodTypes !== $returnTypes) {
                 $this->fileStatus->add(
                     new ReturnMismatchWarning(
                         $file->getFileName(),
                         $name,
                         $method['line'],
                         $name,
-                        is_array($method['return']) ? implode('|', $method['return']) : $method['return'],
-                        $method['docblock']['return']
+                        is_array($methodTypes) ? implode('|', $methodTypes) : $methodTypes,
+                        is_array($returnTypes) ? implode('|', $returnTypes) : $returnTypes
                     )
                 );
                 continue;

--- a/src/Code/AbstractClassCode.php
+++ b/src/Code/AbstractClassCode.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDocBlockChecker\Code;
+
+/**
+ * Represents a portion of code belonging to a class
+ *
+ * @author Neil Brayfield <neil@d3r.com>
+ */
+abstract class AbstractClassCode
+{
+    /**
+     * @var string|null
+     */
+    protected $namespace;
+
+    /**
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * @var string
+     */
+    protected $line;
+
+    /**
+     * @var array
+     */
+    protected $uses;
+
+    /**
+     * @return self
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public static function factory(): self
+    {
+        return new static();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * @param string|null $namespace
+     * @return self
+     */
+    public function setNamespace(string $namespace = null): self
+    {
+        $this->namespace = $namespace;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    /**
+     * @param string $class
+     * @return self
+     */
+    public function setClass(string $class): self
+    {
+        $this->class = $class;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUses(): array
+    {
+        return $this->uses;
+    }
+
+    /**
+     * @param array $uses
+     * @return self
+     */
+    public function setUses(array $uses): self
+    {
+        $this->uses = $uses;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLine(): int
+    {
+        return $this->line;
+    }
+
+    /**
+     * @param int $line
+     * @return self
+     */
+    public function setLine(int $line): self
+    {
+        $this->line = $line;
+
+        return $this;
+    }
+}

--- a/src/Code/AbstractCode.php
+++ b/src/Code/AbstractCode.php
@@ -9,7 +9,7 @@ namespace PhpDocBlockChecker\Code;
  *
  * @author Neil Brayfield <neil@d3r.com>
  */
-abstract class AbstractClassCode
+abstract class AbstractCode
 {
     /**
      * @var string|null
@@ -79,6 +79,30 @@ abstract class AbstractClassCode
     }
 
     /**
+     * Get full class
+     *
+     * @return string
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function getFullClass(): string
+    {
+        if ($this->getNamespace()) {
+            return $this->getNamespace() . '\\' . $this->getClass();
+        }
+
+        return $this->getClass();
+    }
+
+    /**
+     * @return string
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function getFullyQualifiedClass(): string
+    {
+        return '\\' . $this->getFullClass();
+    }
+
+    /**
      * @return array
      */
     public function getUses(): array
@@ -113,6 +137,22 @@ abstract class AbstractClassCode
     {
         $this->line = $line;
 
+        return $this;
+    }
+
+    /**
+     * Get the properties from an existing abstract
+     *
+     * @param AbstractCode $abstract
+     * @return self
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function setFromAbstract(AbstractCode $abstract): self
+    {
+        $this->setClass($abstract->getClass());
+        $this->setUses($abstract->getUses());
+        $this->setLine($abstract->getLine());
+        $this->setNamespace($abstract->getNamespace());
         return $this;
     }
 }

--- a/src/Code/AbstractType.php
+++ b/src/Code/AbstractType.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDocBlockChecker\Code;
+
+/**
+ * Represents a type and contains comparison functions for dealing with
+ * composite types
+ *
+ * @author Neil Brayfield <neil@d3r.com>
+ */
+abstract class AbstractType extends AbstractClassCode
+{
+    /** @var array */
+    protected $types = [];
+
+    /**
+     * @param array $types
+     * @return self
+     */
+    public function addTypes(array $types): self
+    {
+        foreach ($types as $type) {
+            $this->addType($type);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $type
+     * @return self
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function addType(string $type): self
+    {
+        $this->types[] = new SubType($type, $this);
+        return $this;
+    }
+}

--- a/src/Code/AbstractType.php
+++ b/src/Code/AbstractType.php
@@ -10,7 +10,7 @@ namespace PhpDocBlockChecker\Code;
  *
  * @author Neil Brayfield <neil@d3r.com>
  */
-abstract class AbstractType extends AbstractClassCode
+abstract class AbstractType extends AbstractCode
 {
     /** @var array */
     protected $types = [];
@@ -29,6 +29,14 @@ abstract class AbstractType extends AbstractClassCode
         return $this;
     }
 
+    /**
+     * @return bool
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function isNullable(): bool
+    {
+        return $this->nullable;
+    }
 
     /**
      * @param array $types
@@ -55,6 +63,15 @@ abstract class AbstractType extends AbstractClassCode
     }
 
     /**
+     * @return array
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
+    /**
      * @return string
      * @author Neil Brayfield <neil@d3r.com>
      */
@@ -70,5 +87,43 @@ abstract class AbstractType extends AbstractClassCode
     public function toString(): string
     {
         return $this->__toString();
+    }
+
+    /**
+     * Set the types using a string that could contain compound types
+     *
+     * @param string $type
+     * @return self
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function addTypesFromString(string $type): self
+    {
+        $types = explode('|', $type);
+
+        foreach ($types as $type) {
+            if ($type === 'null') {
+                $this->setNullable(true);
+                continue;
+            }
+            $this->addType($type);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param \PhpDocBlockChecker\Code\SubType $type
+     * @return bool
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function hasType(SubType $type): bool
+    {
+        foreach ($this->getTypes() as $thisType) {
+            if ($thisType->matches($type)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Code/AbstractType.php
+++ b/src/Code/AbstractType.php
@@ -15,6 +15,21 @@ abstract class AbstractType extends AbstractClassCode
     /** @var array */
     protected $types = [];
 
+    /** @var bool */
+    protected $nullable = false;
+
+    /**
+     * @param bool $bool
+     * @return self
+     */
+    public function setNullable(bool $bool): self
+    {
+        $this->nullable = $bool;
+
+        return $this;
+    }
+
+
     /**
      * @param array $types
      * @return self
@@ -37,5 +52,23 @@ abstract class AbstractType extends AbstractClassCode
     {
         $this->types[] = new SubType($type, $this);
         return $this;
+    }
+
+    /**
+     * @return string
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function __toString()
+    {
+        return implode('|', $this->types);
+    }
+
+    /**
+     * @return string
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function toString(): string
+    {
+        return $this->__toString();
     }
 }

--- a/src/Code/ClassDocBlock.php
+++ b/src/Code/ClassDocBlock.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDocBlockChecker\Code;
+
+/**
+ * Is similar to a method but represents a docblock
+ *
+ * @author Neil Brayfield <neil@d3r.com>
+ */
+class ClassDocBlock extends AbstractCode implements DocBlockInterface
+{
+    use DocBlockTrait;
+}

--- a/src/Code/DocBlockInterface.php
+++ b/src/Code/DocBlockInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDocBlockChecker\Code;
+
+/**
+ * @author Neil Brayfield <neil@d3r.com>
+ */
+interface DocBlockInterface
+{
+    /**
+     * @return bool
+     */
+    public function isInherited(): bool;
+
+    /**
+     * @param bool $inherited
+     * @return self
+     */
+    public function setInherited(bool $inherited): self;
+}

--- a/src/Code/DocBlockTrait.php
+++ b/src/Code/DocBlockTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDocBlockChecker\Code;
+
+/**
+ * Trait for common docblock code
+ *
+ * @author Neil Brayfield <neil@d3r.com>
+ */
+trait DocBlockTrait
+{
+    /** @var bool */
+    protected $inherited = false;
+
+    /**
+     * @param bool $inherited
+     * @return self
+     */
+    public function setInherited(bool $inherited): self
+    {
+        $this->inherited = $inherited;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isInherited(): bool
+    {
+        return $this->inherited;
+    }
+}

--- a/src/Code/Method.php
+++ b/src/Code/Method.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpDocBlockChecker\Code;
 
+use PhpDocBlockChecker\Code\Param;
+
 /**
  * Undocumented model
  *
@@ -11,17 +13,21 @@ namespace PhpDocBlockChecker\Code;
  */
 class Method extends AbstractClassCode
 {
-    /**
-     * @var bool
-     */
+
+    /** @var string */
+    protected $name;
+
+    /** @var array */
+    protected $docBlock;
+
+    /** @var bool */
     protected $hasReturn = false;
 
-
-    /**
-     * @var \PhpDocBlockChecker\Code\ReturnType
-     * @author Neil Brayfield <neil@d3r.com>
-     */
+    /** @var \PhpDocBlockChecker\Code\ReturnType */
     protected $returnType;
+
+    /** @var \PhpDocBlockChecker\Code\Param[] */
+    protected $params = [];
 
     /**     *
      * @param bool $bool
@@ -36,6 +42,15 @@ class Method extends AbstractClassCode
     }
 
     /**
+     * @return bool
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function hasReturn(): bool
+    {
+        return $this->hasReturn;
+    }
+
+    /**
      * @param ReturnType $returnType
      * @return self
      * @author Neil Brayfield <neil@d3r.com>
@@ -45,5 +60,72 @@ class Method extends AbstractClassCode
         $this->returnType = $returnType;
 
         return $this;
+    }
+
+    /**
+     * Get the return type
+     *
+     * @return ReturnType|null
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function getReturnType(): ?ReturnType
+    {
+        return $this->returnType;
+    }
+
+    /**
+     * @param string $name
+     * @return self
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Set the docblock
+     *
+     * @param array|null $docblock
+     * @return self
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function setDocBlock(array $docblock = null): self
+    {
+        $this->docBlock = $docblock;
+
+        return $this;
+    }
+
+    /**
+     * @return array|null
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function getDocblock(): ?array
+    {
+        return $this->docBlock;
+    }
+
+    /**
+     * @param \PhpDocBlockChecker\Code\Param $param
+     * @return self
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function addParam(Param $param): self
+    {
+        $this->params[] = $param;
+
+        return $this;
+    }
+
+    /**
+     * @return \PhpDocBlockChecker\Code\Param[]
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function getParams(): array
+    {
+        return $this->params;
     }
 }

--- a/src/Code/Method.php
+++ b/src/Code/Method.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDocBlockChecker\Code;
+
+/**
+ * Undocumented model
+ *
+ * @author Neil Brayfield <neil@d3r.com>
+ */
+class Method extends AbstractClassCode
+{
+    /**
+     * @var bool
+     */
+    protected $hasReturn = false;
+
+
+    /**
+     * @var \PhpDocBlockChecker\Code\ReturnType
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    protected $returnType;
+
+    /**     *
+     * @param bool $bool
+     * @return self
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function setHasReturn(bool $bool): self
+    {
+        $this->hasReturn = $bool;
+
+        return $this;
+    }
+
+    /**
+     * @param ReturnType $returnType
+     * @return self
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function setReturnType(ReturnType $returnType): self
+    {
+        $this->returnType = $returnType;
+
+        return $this;
+    }
+}

--- a/src/Code/Method.php
+++ b/src/Code/Method.php
@@ -5,19 +5,20 @@ declare(strict_types=1);
 namespace PhpDocBlockChecker\Code;
 
 use PhpDocBlockChecker\Code\Param;
+use PhpDocBlockChecker\Code\MethodDocBlock;
 
 /**
  * Undocumented model
  *
  * @author Neil Brayfield <neil@d3r.com>
  */
-class Method extends AbstractClassCode
+class Method extends AbstractCode
 {
 
     /** @var string */
     protected $name;
 
-    /** @var array */
+    /** @var \PhpDocBlockChecker\Code\MethodDocBlock */
     protected $docBlock;
 
     /** @var bool */
@@ -51,11 +52,11 @@ class Method extends AbstractClassCode
     }
 
     /**
-     * @param ReturnType $returnType
+     * @param ReturnType|null $returnType
      * @return self
      * @author Neil Brayfield <neil@d3r.com>
      */
-    public function setReturnType(ReturnType $returnType): self
+    public function setReturnType(ReturnType $returnType = null): self
     {
         $this->returnType = $returnType;
 
@@ -88,11 +89,11 @@ class Method extends AbstractClassCode
     /**
      * Set the docblock
      *
-     * @param array|null $docblock
+     * @param \PhpDocBlockChecker\Code\MethodDocBlock $docblock
      * @return self
      * @author Neil Brayfield <neil@d3r.com>
      */
-    public function setDocBlock(array $docblock = null): self
+    public function setDocBlock(MethodDocBlock $docblock = null): self
     {
         $this->docBlock = $docblock;
 
@@ -100,10 +101,10 @@ class Method extends AbstractClassCode
     }
 
     /**
-     * @return array|null
+     * @return \PhpDocBlockChecker\Code\MethodDocBlock|null
      * @author Neil Brayfield <neil@d3r.com>
      */
-    public function getDocblock(): ?array
+    public function getDocblock(): ?MethodDocBlock
     {
         return $this->docBlock;
     }
@@ -115,7 +116,7 @@ class Method extends AbstractClassCode
      */
     public function addParam(Param $param): self
     {
-        $this->params[] = $param;
+        $this->params[$param->getName()] = $param;
 
         return $this;
     }
@@ -127,5 +128,31 @@ class Method extends AbstractClassCode
     public function getParams(): array
     {
         return $this->params;
+    }
+
+    /**
+     * Get the parameter by the name key
+     *
+     * @param string $name
+     * @return \PhpDocBlockChecker\Code\Param|null
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function getParam(string $name): ?Param
+    {
+        if (!$this->hasParam($name)) {
+            return null;
+        }
+
+        return $this->params[$name];
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function hasParam(string $name): bool
+    {
+        return isset($this->params[$name]);
     }
 }

--- a/src/Code/MethodDocBlock.php
+++ b/src/Code/MethodDocBlock.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDocBlockChecker\Code;
+
+use PhpDocBlockChecker\Code\SubType;
+
+/**
+ * Is similar to a method but represents a docblock
+ *
+ * @author Neil Brayfield <neil@d3r.com>
+ */
+class MethodDocBlock extends Method implements DocBlockInterface
+{
+    use DocBlockTrait;
+}

--- a/src/Code/Param.php
+++ b/src/Code/Param.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDocBlockChecker\Code;
+
+/**
+ * A type with a name
+ *
+ * @author Neil Brayfield <neil@d3r.com>
+ */
+class Param extends AbstractType
+{
+    /** @var string */
+    protected $name;
+
+    /** @var bool */
+    protected $variadic = false;
+
+    /**
+     * @param string $name
+     * @return self
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $bool
+     * @return self
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function setVariadic(bool $bool): self
+    {
+        $this->variadic = $bool;
+
+        return $this;
+    }
+}

--- a/src/Code/Param.php
+++ b/src/Code/Param.php
@@ -24,9 +24,22 @@ class Param extends AbstractType
      */
     public function setName(string $name): self
     {
+        if (strpos($name, '$') !== 0) {
+            $name = '$' . $name;
+        }
+
         $this->name = $name;
 
         return $this;
+    }
+
+    /**
+     * @return string
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function getName(): string
+    {
+        return $this->name;
     }
 
     /**
@@ -39,5 +52,16 @@ class Param extends AbstractType
         $this->variadic = $bool;
 
         return $this;
+    }
+
+    /**
+     * Is this a variadic param
+     *
+     * @return bool
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function isVariadic(): bool
+    {
+        return $this->variadic;
     }
 }

--- a/src/Code/ReturnType.php
+++ b/src/Code/ReturnType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDocBlockChecker\Code;
+
+/**
+ * Undocumented model
+ *
+ * @author Neil Brayfield <neil@d3r.com>
+ */
+class ReturnType extends AbstractType
+{
+}

--- a/src/Code/SubType.php
+++ b/src/Code/SubType.php
@@ -33,4 +33,13 @@ class SubType extends AbstractClassCode
         $this->parent = $parent;
         $this->type = $type;
     }
+
+    /**
+     * @return string
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function __toString()
+    {
+        return $this->type;
+    }
 }

--- a/src/Code/SubType.php
+++ b/src/Code/SubType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDocBlockChecker\Code;
+
+/**
+ * Represents a single type not a composite type
+ *
+ * @author Neil Brayfield <neil@d3r.com>
+ */
+class SubType extends AbstractClassCode
+{
+    /**
+     * @var \PhpDocBlockChecker\Code\AbstractClassCode
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    protected $parent;
+
+    /**
+     * @var string
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    protected $type;
+
+    /**
+     * @param string $type
+     * @param \PhpDocBlockChecker\Code\AbstractClassCode $parent
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function __construct(string $type, AbstractClassCode $parent)
+    {
+        $this->parent = $parent;
+        $this->type = $type;
+    }
+}

--- a/src/Code/SubType.php
+++ b/src/Code/SubType.php
@@ -9,10 +9,10 @@ namespace PhpDocBlockChecker\Code;
  *
  * @author Neil Brayfield <neil@d3r.com>
  */
-class SubType extends AbstractClassCode
+class SubType extends AbstractCode
 {
     /**
-     * @var \PhpDocBlockChecker\Code\AbstractClassCode
+     * @var \PhpDocBlockChecker\Code\AbstractCode
      * @author Neil Brayfield <neil@d3r.com>
      */
     protected $parent;
@@ -25,13 +25,74 @@ class SubType extends AbstractClassCode
 
     /**
      * @param string $type
-     * @param \PhpDocBlockChecker\Code\AbstractClassCode $parent
+     * @param \PhpDocBlockChecker\Code\AbstractCode $parent
      * @author Neil Brayfield <neil@d3r.com>
      */
-    public function __construct(string $type, AbstractClassCode $parent)
+    public function __construct(string $type, AbstractCode $parent)
     {
         $this->parent = $parent;
         $this->type = $type;
+    }
+
+    /**
+     * @param SubType $subType
+     * @return bool
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function matches(SubType $subType): bool
+    {
+        if ($subType->getType() === $this->getType()) {
+            return true;
+        }
+
+        if ($subType->isSelfClass() && $this->isSelfClass()) {
+            return true;
+        }
+
+        if ($subType->getType() === 'array' && $this->isTypedArray()) {
+            return true;
+        }
+
+        if ($this->getType() === 'array' && $subType->isTypedArray()) {
+            return true;
+        }
+
+        if ($subType->getFullyQualified() === $this->getFullyQualified()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the full qualified version of this variable
+     *
+     * @return string
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function getFullyQualified(): string
+    {
+        if ($this->isPrimative()) {
+            return $this->type;
+        }
+
+        $uses = $this->parent->getUses();
+
+        if (isset($uses[$this->type])) {
+            $fqt = $uses[$this->type];
+            return strpos($fqt, '\\') !== 0 ? '\\' . $fqt : $fqt;
+        }
+
+        return strpos($this->type, '\\') !== 0 ? '\\' . $this->type : $this->type;
+    }
+
+    /**
+     * @return string
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function getType(): string
+    {
+        return $this->type;
     }
 
     /**
@@ -41,5 +102,49 @@ class SubType extends AbstractClassCode
     public function __toString()
     {
         return $this->type;
+    }
+
+    /**
+     * @return bool
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function isPrimative(): bool
+    {
+        return in_array($this->type, [
+            'bool',
+            'int',
+            'array',
+            'mixed',
+            'class',
+            'object',
+            'float',
+            'string',
+            'resource',
+            'callable',
+            'iterable',
+            'void'
+        ]);
+    }
+
+    /**
+     * @return bool
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function isSelfClass(): bool
+    {
+        if (in_array($this->type, ['static', 'self'])) {
+            return true;
+        }
+
+        return $this->parent->getNamespace() . '\\' . $this->type === $this->parent->getFullClass();
+    }
+
+    /**
+     * @return bool
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function isTypedArray(): bool
+    {
+        return substr($this->type, -2, 2) === '[]';
     }
 }

--- a/src/DocblockParser/ParamTag.php
+++ b/src/DocblockParser/ParamTag.php
@@ -7,15 +7,21 @@ class ParamTag extends Tag
     /**
      * @var string
      */
-    private $type;
+    private $type = '';
     /**
      * @var string
      */
-    private $var;
+    private $var = '';
     /**
      * @var string
      */
-    private $desc;
+    private $desc = '';
+
+    /**
+     * @var string
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    private $variadic = false;
 
     /**
      * ParamTag constructor.
@@ -32,9 +38,15 @@ class ParamTag extends Tag
             return;
         }
 
-        $this->type = isset($parts[0]) ? $parts[0] : '';
-        $this->var = isset($parts[1]) ? $parts[1] : '';
-        $this->desc = isset($parts[2]) ? $parts[2] : '';
+        if (isset($parts[0])) {
+            $this->type = $parts[0];
+        }
+        if (isset($parts[1])) {
+            $this->parseName($parts[1]);
+        }
+        if (isset($parts[2])) {
+            $this->desc = $parts[2];
+        }
     }
 
     /**
@@ -59,5 +71,37 @@ class ParamTag extends Tag
     public function getDesc()
     {
         return $this->desc;
+    }
+
+    /**
+     * @return bool
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    public function isVariadic(): bool
+    {
+        return $this->variadic;
+    }
+
+    /**
+     * Parse the name working out if it's variadic or not
+     *
+     * @param string $name
+     * @author Neil Brayfield <neil@d3r.com>
+     */
+    private function parseName(string $name): void
+    {
+        $name = trim($name);
+
+        if (preg_match("/,\.\.\.$/", $name)) {
+            $this->variadic = true;
+            $name = substr($name, 0, -4);
+        }
+
+        if (preg_match("/^\.\.\.\$/", $name)) {
+            $this->variadic = true;
+            $name = substr($name, 3);
+        }
+
+        $this->var = $name;
     }
 }

--- a/src/FileInfo.php
+++ b/src/FileInfo.php
@@ -70,6 +70,7 @@ class FileInfo implements \JsonSerializable
         return $this->mtime;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/FileParser/FileParser.php
+++ b/src/FileParser/FileParser.php
@@ -193,7 +193,6 @@ class FileParser
                             $name = $param->var->name;
                         }
 
-
                         if (property_exists($param, 'variadic') && $param->variadic) {
                             $name .= ',...';
                         }

--- a/src/FileParser/FileParser.php
+++ b/src/FileParser/FileParser.php
@@ -6,6 +6,7 @@ use PhpDocBlockChecker\DocblockParser\DocblockParser;
 use PhpDocBlockChecker\DocblockParser\ReturnTag;
 use PhpDocBlockChecker\FileInfo;
 use PhpParser\Comment\Doc;
+use PhpParser\Node\ComplexType;
 use PhpParser\Node\Expr;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
@@ -14,6 +15,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\UnionType;
 use PhpParser\NodeAbstract;
 use PhpParser\Parser;
 
@@ -120,6 +122,8 @@ class FileParser
 
                     if ($type instanceof NullableType) {
                         $type = $type->type->toString();
+                    } elseif ($type instanceof UnionType) {
+                        $type = trim(implode('|', $type->types));
                     } elseif ($type instanceof NodeAbstract) {
                         $type = $type->toString();
                     }
@@ -154,6 +158,8 @@ class FileParser
 
                         if ($type instanceof NullableType) {
                             $type = $type->type->toString();
+                        } elseif ($type instanceof UnionType) {
+                            $type = trim(implode('|', $type->types));
                         } elseif ($type instanceof NodeAbstract) {
                             $type = $type->toString();
                         }

--- a/src/FileParser/FileParser.php
+++ b/src/FileParser/FileParser.php
@@ -142,6 +142,7 @@ class FileParser
                     }
 
                     $thisMethod = [
+                        'namespace' => $prefix,
                         'file' => $file,
                         'class' => $fullClassName,
                         'name' => $fullMethodName,
@@ -190,6 +191,11 @@ class FileParser
                         // parser v4
                         if (null === $name && property_exists($param, 'var') && property_exists($param->var, 'name')) {
                             $name = $param->var->name;
+                        }
+
+
+                        if (property_exists($param, 'variadic') && $param->variadic) {
+                            $name .= ',...';
                         }
 
                         $thisMethod['params']['$' . $name] = $type;

--- a/src/FileProvider/FileExclusionFilter.php
+++ b/src/FileProvider/FileExclusionFilter.php
@@ -31,7 +31,7 @@ class FileExclusionFilter extends \FilterIterator
      * @return bool true if the current element is acceptable, otherwise false.
      * @since 5.1.0
      */
-    public function accept()
+    public function accept(): bool
     {
         $file = $this->getInnerIterator()->current();
         return !$this->isFileExcluded($this->baseDirectory, $file);

--- a/src/Status/StatusType/Warning/ParamMismatchWarning.php
+++ b/src/Status/StatusType/Warning/ParamMismatchWarning.php
@@ -87,6 +87,6 @@ class ParamMismatchWarning extends Warning
     {
         return parent::getDecoratedMessage() . '<info>' . $this->method . '</info> - @param <fg=blue>' .
             $this->param . '</> (' . $this->docType .
-            ')  does not match method signature (' . $this->paramType . ').';
+            ') does not match method signature <fg=blue>' . $this->paramType . '</>.';
     }
 }

--- a/src/Status/StatusType/Warning/ReturnMismatchWarning.php
+++ b/src/Status/StatusType/Warning/ReturnMismatchWarning.php
@@ -55,7 +55,7 @@ class ReturnMismatchWarning extends Warning
      */
     public function getReturnType()
     {
-        return $this->returnType;
+        return $this->returnType ?: 'void';
     }
 
     /**
@@ -73,6 +73,6 @@ class ReturnMismatchWarning extends Warning
     {
         return parent::getDecoratedMessage() . '<info>' . $this->method .
             '</info> - @return <fg=blue>' . $this->docType .
-            '</>  does not match method signature (' . $this->returnType . ').';
+            '</> does not match method signature <fg=blue>' . $this->returnType . '</>.';
     }
 }


### PR DESCRIPTION
Moves away from trying to make a string comparison on types and use objects instead

We still don't handle intersection types or DNF types but this allows that to be easier to add.